### PR TITLE
Update EdsbyTermInfo.ps1

### DIFF
--- a/Edsby/EdsbyTermInfo.ps1
+++ b/Edsby/EdsbyTermInfo.ps1
@@ -14,7 +14,7 @@ $SqlQuery = "SELECT
                 T.iSchoolID AS SchoolID, 
                 (FORMAT(TE.dEndDate, 'yy') -1) AS SchoolYear, 
                 TE.iTermID AS TermID, 
-                REPLACE(TE.cName, 'SEMESTER', 'Sem') AS Title, 
+                TE.cName AS Title, 
                 FORMAT(TE.dStartDate, 'yyyy-MM-dd') as Start, 
                 FORMAT(TE.dEndDate,'yyyy-MM-dd') AS 'End' 
             FROM 


### PR DESCRIPTION
Removing the shortening of the term name as Edsby Limit is due to the Sandbox not the length of the string.