### PR TITLE
Update EdsbySchoolInfo.ps1

### DIFF
--- a/Edsby/EdsbySchoolInfo.ps1
+++ b/Edsby/EdsbySchoolInfo.ps1
@@ -13,7 +13,13 @@ param (
 $SqlQuery = "SELECT
                 S.iSchoolID AS SchoolID,
                 LTRIM(RTRIM(S.cName)) AS SchoolName,
-                LTRIM(RTRIM(ST.cName)) AS SchoolType,
+                CASE WHEN
+					LTRIM(RTRIM(ST.cName)) = 'PS'
+				THEN
+					'E'
+				ELSE
+					LTRIM(RTRIM(ST.cName))
+				END AS SchoolType,
                 'Regular' AS SchoolFocus,
                 '' AS DistrictID,
                 LTRIM(RTRIM(URL.mInfo)) AS SchoolURL,


### PR DESCRIPTION
Updated SQL to replace 'PS' with 'E' as requested by Edsby. 'HS' & 'K12' will probably send warnings, but Edsby doesn't have codes that make sense to replace those yet.