### PR TITLE
Skip records causing errors in Clever

### DIFF
--- a/Clever/CleverSections.ps1
+++ b/Clever/CleverSections.ps1
@@ -54,6 +54,7 @@ $SqlQuery = "SELECT
             WHERE
                 Class.iDefault_StaffID > 0
                 AND (SELECT COUNT(iEnrollmentID) FROM Enrollment WHERE iClassID=Class.iClassID) > 0
+                AND (LEN(DefaultUserStaff.UF_2085) > 0)
             ORDER BY
                 Class.iClassID
 "

--- a/Clever/CleverSections.ps1
+++ b/Clever/CleverSections.ps1
@@ -53,7 +53,7 @@ $SqlQuery = "SELECT
                 LEFT OUTER JOIN UserStaff as DefaultUserStaff ON DefaultStaff.iStaffID=DefaultUserStaff.iStaffID
             WHERE
                 Class.iDefault_StaffID > 0
-                AND (SELECT COUNT(iEnrollmentID) FROM Enrollment WHERE iClassID=Class.iClassID) > 0
+                AND (SELECT COUNT(iEnrollmentID) FROM Enrollment WHERE iClassID=Class.iClassID AND Enrollment.iLV_CompletionStatusID=0) > 0
                 AND (LEN(DefaultUserStaff.UF_2085) > 0)
             ORDER BY
                 Class.iClassID


### PR DESCRIPTION
- Skip sections taught by teachers with no certificate number
- Skip withdrawn or completed students when determining if there are students in a class