### PR TITLE
Change SchoolMessenger address book file to match new file format

### DIFF
--- a/SchoolMessenger/SchoolMessengerAddressBook.ps1
+++ b/SchoolMessenger/SchoolMessengerAddressBook.ps1
@@ -23,28 +23,52 @@ $SqlQuery = "SELECT
                 Student.cFirstName as StudentFirstName,
                 REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(RTRIM(LTRIM(Grades.cName)),'0K','K'),'01','1'),'02','2'),'03','3'),'04','4'),'05','5'),'06','6'),'07','7'),'08','8'),'09','9') as Grade,
                 Homeroom.cName as HomeRoom,
-                Contact.cLastName as ContactLastName,
-                Contact.cFirstName as ContactFirstName,
-                ContactRelationLV.cName as ContactRelation,
-                ContactRelation.iContactPriority as ContactPriority,
-                ContactLocation.cPhone as ContactHomePhone,
-                Contact.mCellPhone as ContactMobilePhone,
-                Contact.cBusPhone as ContactWorkPhone,
-                Contact.mEmail as ContactEmail
+                Contact1_RELATIONLV.cName as Contact1Relation,
+                Contact1_CONTACT.cLastName as Contact1LastName,
+                Contact1_CONTACT.cFirstName as Contact1FirstName,
+                Contact1_LOCATION.cPhone as Contact1HomePhone,
+                Contact1_CONTACT.mCellphone as Contact1CellPhone,
+                Contact1_CONTACT.cBusPhone as Contact1WorkPhone,
+                Contact1_CONTACT.mEmail as Contact1Email,
+                Contact2_RELATIONLV.cName as Contact2Relation,
+                Contact2_CONTACT.cLastName as Contact2LastName,
+                Contact2_CONTACT.cFirstName as Contact2FirstName,
+                Contact2_LOCATION.cPhone as Contact2HomePhone,
+                Contact2_CONTACT.mCellphone as Contact2CellPhone,
+                Contact2_CONTACT.cBusPhone as Contact2WorkPhone,
+                Contact2_CONTACT.mEmail as Contact2Email,
+                Contact3_RELATIONLV.cName as Contact3Relation,
+                Contact3_CONTACT.cLastName as Contact3LastName,
+                Contact3_CONTACT.cFirstName as Contact3FirstName,
+                Contact3_LOCATION.cPhone as Contact3HomePhone,
+                Contact3_CONTACT.mCellphone as Contact3CellPhone,
+                Contact3_CONTACT.cBusPhone as Contact3WorkPhone,
+                Contact3_CONTACT.mEmail as Contact3Email
             FROM
                 StudentStatus
                 LEFT OUTER JOIN Student ON StudentStatus.iStudentID=Student.iStudentID
                 LEFT OUTER JOIN School ON Student.iSchoolID=School.iSchoolID
                 LEFT OUTER JOIN Grades ON Student.iGradesID=Grades.iGradesID
                 LEFT OUTER JOIN Homeroom ON Student.iHomeroomID=Homeroom.iHomeroomID
-                LEFT OUTER JOIN ContactRelation ON Student.iStudentID=ContactRelation.iStudentID
-                LEFT OUTER JOIN Contact ON ContactRelation.iContactID=Contact.iContactID
-                LEFT OUTER JOIN LookupValues AS ContactRelationLV ON ContactRelation.iLV_RelationID=ContactRelationLV.iLookupValuesID
-                LEFT OUTER JOIN Location AS ContactLocation ON Contact.iLocationID=ContactLocation.iLocationID
+                LEFT OUTER JOIN (SELECT CR_o.iStudentID, CR_1.iContactRelationID FROM (SELECT DISTINCT iStudentID FROM ContactRelation) CR_o CROSS APPLY (SELECT iContactID,iContactRelationID FROM ContactRelation CR_i WHERE CR_i.iStudentID=CR_o.iStudentID AND (lMail=1 OR Notify=1) ORDER BY iContactPriority OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY) CR_1) as ContactRID1 ON ContactRID1.iStudentID=Student.iStudentID
+                LEFT OUTER JOIN (SELECT CR_o.iStudentID, CR_1.iContactRelationID FROM (SELECT DISTINCT iStudentID FROM ContactRelation) CR_o CROSS APPLY (SELECT iContactID,iContactRelationID FROM ContactRelation CR_i WHERE CR_i.iStudentID=CR_o.iStudentID AND (lMail=1 OR Notify=1) ORDER BY iContactPriority OFFSET 1 ROWS FETCH NEXT 1 ROWS ONLY) CR_1) as ContactRID2 ON ContactRID2.iStudentID=Student.iStudentID
+                LEFT OUTER JOIN (SELECT CR_o.iStudentID, CR_1.iContactRelationID FROM (SELECT DISTINCT iStudentID FROM ContactRelation) CR_o CROSS APPLY (SELECT iContactID,iContactRelationID FROM ContactRelation CR_i WHERE CR_i.iStudentID=CR_o.iStudentID AND (lMail=1 OR Notify=1) ORDER BY iContactPriority OFFSET 2 ROWS FETCH NEXT 1 ROWS ONLY) CR_1) as ContactRID3 ON ContactRID3.iStudentID=Student.iStudentID
+                LEFT OUTER JOIN ContactRelation as Contact1_RELATION ON ContactRID1.iContactRelationID=Contact1_RELATION.iContactRelationID
+                LEFT OUTER JOIN Contact as Contact1_CONTACT ON Contact1_RELATION.iContactID=Contact1_CONTACT.iContactID
+                LEFT OUTER JOIN LookupValues AS Contact1_RELATIONLV ON Contact1_RELATION.iLV_RelationID=Contact1_RELATIONLV.iLookupValuesID
+                LEFT OUTER JOIN Location AS Contact1_LOCATION ON Contact1_CONTACT.iLocationID=Contact1_LOCATION.iLocationID
+                LEFT OUTER JOIN ContactRelation as Contact2_RELATION ON ContactRID2.iContactRelationID=Contact2_RELATION.iContactRelationID
+                LEFT OUTER JOIN Contact as Contact2_CONTACT ON Contact2_RELATION.iContactID=Contact2_CONTACT.iContactID
+                LEFT OUTER JOIN LookupValues AS Contact2_RELATIONLV ON Contact2_RELATION.iLV_RelationID=Contact2_RELATIONLV.iLookupValuesID
+                LEFT OUTER JOIN Location AS Contact2_LOCATION ON Contact2_CONTACT.iLocationID=Contact2_LOCATION.iLocationID
+                LEFT OUTER JOIN ContactRelation as Contact3_RELATION ON ContactRID3.iContactRelationID=Contact3_RELATION.iContactRelationID
+                LEFT OUTER JOIN Contact as Contact3_CONTACT ON Contact3_RELATION.iContactID=Contact3_CONTACT.iContactID
+                LEFT OUTER JOIN LookupValues AS Contact3_RELATIONLV ON Contact3_RELATION.iLV_RelationID=Contact3_RELATIONLV.iLookupValuesID
+                LEFT OUTER JOIN Location AS Contact3_LOCATION ON Contact3_CONTACT.iLocationID=Contact3_LOCATION.iLocationID
             WHERE
-                (StudentStatus.dInDate <= getDate()) AND
-                ((StudentStatus.dOutDate < '1901-01-01') OR (StudentStatus.dOutDate >= getDate())) AND	
-                (ContactRelation.lMail=1 OR ContactRelation.Notify=1)"
+                (StudentStatus.dInDate <= getDate()) 
+                AND ((StudentStatus.dOutDate <= '1901-01-01') OR (StudentStatus.dOutDate >= getDate()))
+                AND (Contact1_CONTACT.iContactID IS NOT NULL)"
 
 # CSV Delimeter
 # Some systems expect this to be a tab "`t" or a pipe "|".


### PR DESCRIPTION
Trying to edit the file, it appears that they now expect parents and guardians to all be on the same line rather than having the students duplicated in the file. 