### PR TITLE
Use switches instead of bools for parameters

### DIFF
--- a/SchoolMessenger/SchoolMessengerAttendance.ps1
+++ b/SchoolMessenger/SchoolMessengerAttendance.ps1
@@ -1,7 +1,7 @@
 param (
     [Parameter(Mandatory=$true)][string]$OutputFileName,
-    [bool]$JustPeriodAttendance,
-    [bool]$JustDailyAttendance,
+    [switch]$JustPeriodAttendance,
+    [switch]$JustDailyAttendance,
     [string]$DateFrom,
     [string]$DateTo,
     [string]$SchoolIDs,


### PR DESCRIPTION
Because I'm having issues with passing bool values from an array of parameters in an outer powershell script, and hopefully this will help.