### PR TITLE
Fix output file path

### DIFF
--- a/Utilities/CombineCSVFiles.ps1
+++ b/Utilities/CombineCSVFiles.ps1
@@ -33,7 +33,8 @@ if ($HeaderLines -gt 0) {
     }
 }
 
-$file = [system.io.file]::OpenWrite("$($pwd.Path)\$OutputFileName")
+
+$file = [system.io.file]::OpenWrite($OutputFileName)
 $writer = New-Object System.IO.StreamWriter($file)
 
 # Write the file headings


### PR DESCRIPTION
This crashes when running as a scheduled task, so don't try to fix the filename, just take what's given.